### PR TITLE
Refactor: Rename attribute for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ class Product
 ```
 
 ### ✳️ Option 2: Assigning Snowflake ID to Custom Fields
-Use the `#[AutoSnowflake]` attribute to mark any non-ID field for automatic generation:
+Use the `#[SnowflakeColumn]` attribute to mark any non-ID field for automatic generation:
 
 ```php
-use JeanCodogno\DoctrineSnowflakeIdBundle\Attributes\AutoSnowflake;
+use JeanCodogno\DoctrineSnowflakeIdBundle\Attributes\SnowflakeColumn;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
 class Product
 {
     #[ORM\Column(type: 'bigint', unique: true)]
-    #[AutoSnowflake]
+    #[SnowflakeColumn]
     private ?string $publicId = null;
 
     // ...

--- a/src/Attributes/SnowflakeColumn.php
+++ b/src/Attributes/SnowflakeColumn.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 namespace JeanCodogno\DoctrineSnowflakeIdBundle\Attributes;
 
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class AutoSnowflake
+final class SnowflakeColumn
 {
 }

--- a/src/DoctrineSnowflakeIdBundle.php
+++ b/src/DoctrineSnowflakeIdBundle.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JeanCodogno\DoctrineSnowflakeIdBundle;
 
-use JeanCodogno\DoctrineSnowflakeIdBundle\EventListener\AutoSnowflakeListener;
+use JeanCodogno\DoctrineSnowflakeIdBundle\EventListener\SnowflakeListener;
 use JeanCodogno\DoctrineSnowflakeIdBundle\Services\SnowflakeGenerator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -20,7 +20,7 @@ final class DoctrineSnowflakeIdBundle extends Bundle
             ->setAutoconfigured(true)
             ->setPublic(true);
 
-        $container->register(AutoSnowflakeListener::class)
+        $container->register(SnowflakeListener::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)
             ->addTag('doctrine.event_listener', ['event' => 'prePersist']);

--- a/src/EventListener/SnowflakeListener.php
+++ b/src/EventListener/SnowflakeListener.php
@@ -7,11 +7,11 @@ namespace JeanCodogno\DoctrineSnowflakeIdBundle\EventListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Events;
-use JeanCodogno\DoctrineSnowflakeIdBundle\Attributes\AutoSnowflake;
+use JeanCodogno\DoctrineSnowflakeIdBundle\Attributes\SnowflakeColumn;
 use JeanCodogno\DoctrineSnowflakeIdBundle\Services\SnowflakeGenerator;
 
 #[AsDoctrineListener(event: Events::prePersist, priority: 500, connection: 'default')]
-final class AutoSnowflakeListener
+final class SnowflakeListener
 {
     public function __construct(
         private SnowflakeGenerator $generator
@@ -24,7 +24,7 @@ final class AutoSnowflakeListener
         $reflection = new \ReflectionClass($entity);
 
         foreach ($reflection->getProperties() as $property) {
-            $attributes = $property->getAttributes(AutoSnowflake::class);
+            $attributes = $property->getAttributes(SnowflakeColumn::class);
             if ($attributes !== []) {
                 $property->setAccessible(true);
                 if ($property->getValue($entity) === null) {


### PR DESCRIPTION
## Refactor: Rename attribute for clarity

Renamed `AutoSnowflake` to `SnowflakeColumn` to better reflect its purpose.
